### PR TITLE
feat(products): add S3 image sync runner on startup

### DIFF
--- a/src/main/java/team/upao/dev/products/config/ProductImageSyncRunner.java
+++ b/src/main/java/team/upao/dev/products/config/ProductImageSyncRunner.java
@@ -1,0 +1,31 @@
+package team.upao.dev.products.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team.upao.dev.products.service.ProductService;
+
+/**
+ * Al arrancar la aplicación, sincroniza las imageUrl de los productos
+ * con los archivos que existen en el bucket S3 bajo el prefijo "products/".
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductImageSyncRunner {
+
+    private final ProductService productService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void syncOnStartup() {
+        try {
+            log.info("Ejecutando sincronización automática de imágenes con S3...");
+            int updated = productService.syncImagesFromS3();
+            log.info("Sincronización de imágenes completada: {} producto(s) actualizados.", updated);
+        } catch (Exception e) {
+            log.warn("No se pudo sincronizar imágenes con S3 al arrancar: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Adds ProductImageSyncRunner that listens to ApplicationReadyEvent and automatically syncs product imageUrl columns in DB by matching slugified product names against S3 objects under the products/ prefix.