### PR TITLE
perf: eliminar Redis, optimizar JVM, HikariCP y logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY src ./src
 RUN mvn -B clean package -DskipTests
 
 # Etapa 2: Ejecución
-FROM eclipse-temurin:21-jdk
+FROM eclipse-temurin:21-jre
 
 WORKDIR /app
 
@@ -31,4 +31,10 @@ COPY --from=build /app/target/*.jar /app/punto_de_sal.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/punto_de_sal.jar"]
+ENTRYPOINT ["java", \
+  "-XX:MaxRAMPercentage=60.0", \
+  "-XX:InitialRAMPercentage=25.0", \
+  "-XX:+UseG1GC", \
+  "-XX:+OptimizeStringConcat", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "/app/punto_de_sal.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -164,16 +164,6 @@
             <version>2.42.26</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.session</groupId>
-            <artifactId>spring-session-data-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>redis.clients</groupId>
-            <artifactId>jedis</artifactId>
-            <version>7.4.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,15 +19,15 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.validate-on-migrate=true
 spring.flyway.placeholders.schemaName=public
 
-# Flyway Debug Logging
-logging.level.org.flywaydb=DEBUG
+# Logging
+logging.level.org.flywaydb=WARN
 
 # File upload
 spring.servlet.multipart.max-file-size=50MB
 
 # Logging
 # logging.level.org.hibernate.SQL=DEBUG
-logging.level.software.amazon.awssdk=DEBUG
+logging.level.software.amazon.awssdk=WARN
 
 # Jwt
 jwt.secret.key=${JWT_SECRET_KEY}
@@ -70,12 +70,7 @@ spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-request-size=10MB
 spring.destination.folder="src/main/resources/static/"
 
-# Redis
-spring.session.store-type=redis
-spring.data.redis.host=${REDIS_HOST}
-spring.data.redis.port=${REDIS_PORT}
-spring.data.redis.password=${REDIS_PASSWORD}
-spring.data.redis.timeout=60000ms
-spring.data.redis.jedis.pool.max-active=8
-spring.data.redis.jedis.pool.max-idle=8
-spring.data.redis.jedis.pool.min-idle=0
+# HikariCP
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=20000


### PR DESCRIPTION
- Eliminar spring-session-data-redis y jedis (Redis era redundante con JWT stateless)
- HikariCP: reducir pool de 10 a 5 conexiones (max), min-idle=1
- JVM: MaxRAMPercentage=60, G1GC, java.security.egd para startup más rápido
- Docker: cambiar eclipse-temurin:21-jdk a 21-jre (~200MB menos en imagen)
- Logs: flywaydb y awssdk de DEBUG a WARN